### PR TITLE
meta_search and Ransack

### DIFF
--- a/app/controllers/spree/admin/contents_controller.rb
+++ b/app/controllers/spree/admin/contents_controller.rb
@@ -29,10 +29,10 @@ class Spree::Admin::ContentsController < Spree::Admin::ResourceController
     end
 
     def collection
-      params[:search] ||= {}
-      params[:search][:meta_sort] ||= "page.asc"
-      @search = parent.contents.metasearch(params[:search])
-      @collection = @search.page(params[:page]).per(Spree::Config[:orders_per_page])
+      params[:q] ||= {}
+      params[:q][:sort] ||= "page.asc"
+      @search = parent.contents.search(params[:q])
+      @collection = @search.result.page(params[:page]).per(Spree::Config[:orders_per_page])
     end
 
 end

--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -26,10 +26,10 @@ class Spree::Admin::PagesController < Spree::Admin::ResourceController
     end
     
     def collection
-      params[:search] ||= {}
-      params[:search][:meta_sort] ||= "page.asc"
-      @search = Spree::Page.metasearch(params[:search])
-      @collection = @search.page(params[:page]).per(Spree::Config[:orders_per_page])
+      params[:q] ||= {}
+      params[:q][:sort] ||= "page.asc"
+      @search = Spree::Page.search(params[:q])
+      @collection = @search.result.page(params[:page]).per(Spree::Config[:orders_per_page])
     end
 
 end

--- a/spree_essential_cms.gemspec
+++ b/spree_essential_cms.gemspec
@@ -22,12 +22,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('spree_essentials', '~> 0.4.0.rc3')
   
   # Development
-  s.add_development_dependency('spree_sample', '~> 1.0.0')
+  s.add_development_dependency('spree_sample', '~> 1.1.0.beta')
 	s.add_development_dependency('dummier',      '~> 0.3.2')
 	s.add_development_dependency('shoulda',      '~> 3.0.0')
 	s.add_development_dependency('factory_girl', '~> 2.6.0')
 	s.add_development_dependency('capybara',     '~> 1.1.2')
-  s.add_development_dependency('sqlite3',      '~> 1.3.5')
+  s.add_development_dependency('mysql2',      '~> 1.3.5')
   # s.add_development_dependency('simplecov',    '~> 0.6.1')
   # s.add_development_dependency('turn',         '~> 0.9.3')
   

--- a/spree_essential_cms.gemspec
+++ b/spree_essential_cms.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 	s.add_development_dependency('shoulda',      '~> 3.0.0')
 	s.add_development_dependency('factory_girl', '~> 2.6.0')
 	s.add_development_dependency('capybara',     '~> 1.1.2')
-  s.add_development_dependency('mysql2',      '~> 1.3.5')
+  s.add_development_dependency('sqlite3',      '~> 1.3.5')
   # s.add_development_dependency('simplecov',    '~> 0.6.1')
   # s.add_development_dependency('turn',         '~> 0.9.3')
   


### PR DESCRIPTION
Updated Gemfile for spree_sample version 1.1.0.beta (probably a better way to do that). Modified the pages_controller and contents_controller to use the new params `:q` and removed references to metasearch actions.
